### PR TITLE
feat: create ActiveLink component

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -3,6 +3,9 @@ import type { Preview } from "@storybook/react";
 
 const preview: Preview = {
   parameters: {
+    nextjs: {
+      appDirectory: true,
+    },
     controls: {
       matchers: {
         color: /(background|color)$/i,

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "next-themes": "^0.4.4",
         "normalize.css": "^8.0.1",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "tailwind-merge": "^2.5.5"
       },
       "devDependencies": {
         "@chromatic-com/storybook": "^3.2.2",
@@ -17020,6 +17021,16 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/tailwind-merge": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.5.5.tgz",
+      "integrity": "sha512-0LXunzzAZzo0tEPxV3I297ffKZPlKDrjj7NXphC8V5ak9yHC5zRmxnOe2m/Rd/7ivsOMJe3JZ2JVocoDdQTRBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
     },
     "node_modules/tailwindcss": {
       "version": "3.4.15",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "next-themes": "^0.4.4",
     "normalize.css": "^8.0.1",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "tailwind-merge": "^2.5.5"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^3.2.2",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
 import ThemeProvider from "@/context/ThemesProvider";
+import { cn } from "@/utils";
 
 const figtree = localFont({
   src: "./fonts/Figtree-Variable.woff2",
@@ -36,7 +37,12 @@ export default function RootLayout({
   return (
     <html lang="pl" data-lt-installed="true">
       <body
-        className={`${figtree.variable} ${lora.variable} ${sourceSans.variable} antialiased`}
+        className={cn(
+          figtree.variable,
+          lora.variable,
+          sourceSans.variable,
+          "antialiased",
+        )}
       >
         <ThemeProvider>{children}</ThemeProvider>
       </body>

--- a/src/components/ExampleButton/ExampleButton.tsx
+++ b/src/components/ExampleButton/ExampleButton.tsx
@@ -1,4 +1,4 @@
-import clsx from "clsx";
+import { cn } from "@/utils";
 
 export interface ExampleButtonProps {
   variant: "primary" | "inversion" | "secondary";
@@ -7,16 +7,18 @@ export interface ExampleButtonProps {
 
 export const ExampleButton = ({ variant, label }: ExampleButtonProps) => {
   const variants = {
-    primary: "bg-redMain text-backgroundMain hover:bg-[#7A0003] active:bg-[#520103]",
-    inversion: "bg-backgroundMain text-redMain hover:bg-backgroundB active:bg-[#e8e3da]",
+    primary:
+      "bg-redMain text-backgroundMain hover:bg-[#7A0003] active:bg-[#520103]",
+    inversion:
+      "bg-backgroundMain text-redMain hover:bg-backgroundB active:bg-[#e8e3da]",
     secondary: "bg-greenLight text-black hover:bg-greenC active:bg-greenB",
   };
 
   return (
     <button
-    type="button"
-      className={clsx(
-        "font-sourceSans button-outline h-fit w-[160px] rounded px-8 py-3 text-lg",
+      type="button"
+      className={cn(
+        "button-outline h-fit w-[160px] rounded px-8 py-3 font-sourceSans text-lg",
         variants[variant],
       )}
     >

--- a/src/components/shared/ActiveLink/ActiveLink.stories.tsx
+++ b/src/components/shared/ActiveLink/ActiveLink.stories.tsx
@@ -6,10 +6,37 @@ const meta: Meta<typeof ActiveLink> = {
   component: ActiveLink,
   parameters: {
     layout: "centered",
+    docs: {
+      description: {
+        component:
+          "A Next.js Link component that applies styling based on the current route. Supports exact and non-exact path matching, query parameters, and custom styling.",
+      },
+    },
+  },
+  argTypes: {
+    href: {
+      description: "URL or route object to link to",
+      control: "text",
+    },
+    exact: {
+      description: "Whether to match the path exactly or allow sub-paths",
+      control: "boolean",
+    },
+    className: {
+      description: "Default styling classes",
+      control: "text",
+    },
+    activeClassName: {
+      description: "Classes to apply when link is active",
+      control: "text",
+    },
   },
   decorators: [
     (Story) => (
-      <div className="p-4">
+      <div className="flex flex-col space-y-4 p-4">
+        <p className="text-sm text-gray-500">
+          Current path shown for demo purposes
+        </p>
         <Story />
       </div>
     ),
@@ -19,12 +46,16 @@ const meta: Meta<typeof ActiveLink> = {
 export default meta;
 type Story = StoryObj<typeof ActiveLink>;
 
+const defaultClasses = {
+  className: "text-blue-600 hover:text-blue-800 transition-colors duration-200",
+  activeClassName: "font-bold text-blue-800 underline",
+};
+
 export const Default: Story = {
   args: {
     href: "/example",
     children: "Example Link",
-    className: "text-blue-600 hover:text-blue-800",
-    activeClassName: "font-bold",
+    ...defaultClasses,
   },
 };
 
@@ -39,6 +70,14 @@ export const Active: Story = {
       },
     },
   },
+  decorators: [
+    (Story) => (
+      <div className="space-y-2">
+        <div className="text-xs text-gray-500">Current path: /example</div>
+        <Story />
+      </div>
+    ),
+  ],
 };
 
 export const WithQueryParams: Story = {
@@ -48,16 +87,26 @@ export const WithQueryParams: Story = {
       query: { tab: "settings" },
     },
     children: "Settings Tab",
-    className: "text-blue-600 hover:text-blue-800",
-    activeClassName: "font-bold",
+    ...defaultClasses,
   },
   parameters: {
     nextjs: {
       navigation: {
         pathname: "/example",
+        query: { tab: "settings" },
       },
     },
   },
+  decorators: [
+    (Story) => (
+      <div className="space-y-2">
+        <div className="text-xs text-gray-500">
+          Current path: /example?tab=settings
+        </div>
+        <Story />
+      </div>
+    ),
+  ],
 };
 
 export const NonExactMatching: Story = {
@@ -65,9 +114,45 @@ export const NonExactMatching: Story = {
     href: "/products",
     exact: false,
     children: "Products Section",
-    className: "text-blue-600 hover:text-blue-800",
-    activeClassName: "font-bold",
+    ...defaultClasses,
   },
+  parameters: {
+    nextjs: {
+      navigation: {
+        pathname: "/products/123",
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="space-y-2">
+        <div className="text-xs text-gray-500">Current path: /products/123</div>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const MultipleLinks: Story = {
+  render: () => (
+    <nav className="flex flex-col space-y-2">
+      <ActiveLink href="/dashboard" {...defaultClasses}>
+        Dashboard
+      </ActiveLink>
+      <ActiveLink href="/products" exact={false} {...defaultClasses}>
+        Products
+      </ActiveLink>
+      <ActiveLink
+        href={{
+          pathname: "/settings",
+          query: { tab: "profile" },
+        }}
+        {...defaultClasses}
+      >
+        Settings
+      </ActiveLink>
+    </nav>
+  ),
   parameters: {
     nextjs: {
       navigation: {

--- a/src/components/shared/ActiveLink/ActiveLink.stories.tsx
+++ b/src/components/shared/ActiveLink/ActiveLink.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ActiveLink } from ".";
+
+const meta: Meta<typeof ActiveLink> = {
+  title: "Components/Shared/ActiveLink",
+  component: ActiveLink,
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof ActiveLink>;
+
+export const Default: Story = {
+  args: {
+    href: "/example",
+    children: "Example Link",
+    className: "text-blue-600 hover:text-blue-800",
+    activeClassName: "font-bold",
+  },
+};
+
+export const Active: Story = {
+  args: {
+    ...Default.args,
+  },
+  parameters: {
+    nextjs: {
+      navigation: {
+        pathname: "/example",
+      },
+    },
+  },
+};
+
+export const WithQueryParams: Story = {
+  args: {
+    href: {
+      pathname: "/example",
+      query: { tab: "settings" },
+    },
+    children: "Settings Tab",
+    className: "text-blue-600 hover:text-blue-800",
+    activeClassName: "font-bold",
+  },
+  parameters: {
+    nextjs: {
+      navigation: {
+        pathname: "/example",
+      },
+    },
+  },
+};
+
+export const NonExactMatching: Story = {
+  args: {
+    href: "/products",
+    exact: false,
+    children: "Products Section",
+    className: "text-blue-600 hover:text-blue-800",
+    activeClassName: "font-bold",
+  },
+  parameters: {
+    nextjs: {
+      navigation: {
+        pathname: "/products/123",
+      },
+    },
+  },
+};

--- a/src/components/shared/ActiveLink/ActiveLink.test.tsx
+++ b/src/components/shared/ActiveLink/ActiveLink.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from "@testing-library/react";
+import { usePathname } from "next/navigation";
+import "@testing-library/jest-dom";
+import { ActiveLink } from ".";
+
+jest.mock("next/navigation", () => ({
+  usePathname: jest.fn(),
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: jest.fn(({ children, ...props }) => <a {...props}>{children}</a>),
+}));
+
+const mockedUsePathname = usePathname as jest.Mock;
+
+describe("ActiveLink", () => {
+  beforeEach(() => {
+    mockedUsePathname.mockReset();
+  });
+
+  it("renders children passed to it", () => {
+    render(<ActiveLink href="/path">Home</ActiveLink>);
+
+    expect(screen.getByText("Home")).toBeVisible();
+  });
+
+  it("applies active class when the path is an exact match", () => {
+    mockedUsePathname.mockReturnValue("/path");
+    render(
+      <ActiveLink href="/path" activeClassName="active">
+        Home
+      </ActiveLink>,
+    );
+
+    expect(screen.getByText("Home")).toHaveClass("active");
+  });
+
+  it("does not apply active class when the path does not match exactly and 'exact' is true", () => {
+    mockedUsePathname.mockReturnValue("/path/sub-path");
+    render(
+      <ActiveLink href="/path" activeClassName="active" exact>
+        Home
+      </ActiveLink>,
+    );
+
+    expect(screen.getByText("Home")).not.toHaveClass("active");
+  });
+
+  it("applies active class when the path is not an exact match and 'exact' is false", () => {
+    mockedUsePathname.mockReturnValue("/path/sub-path");
+    render(
+      <ActiveLink href="/path" activeClassName="active" exact={false}>
+        Home
+      </ActiveLink>,
+    );
+
+    expect(screen.getByText("Home")).toHaveClass("active");
+  });
+
+  it("handles href as an object", () => {
+    mockedUsePathname.mockReturnValue("/path");
+    render(
+      <ActiveLink
+        href={{ pathname: "/path", query: { key: "value" } }}
+        activeClassName="active"
+      >
+        Home
+      </ActiveLink>,
+    );
+
+    expect(screen.getByText("Home")).toHaveClass("active");
+  });
+
+  it("applies provided custom styles", () => {
+    render(
+      <ActiveLink href="/path" className="custom-class">
+        Home
+      </ActiveLink>,
+    );
+
+    expect(screen.getByText("Home")).toHaveClass("custom-class");
+  });
+});

--- a/src/components/shared/ActiveLink/index.tsx
+++ b/src/components/shared/ActiveLink/index.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { type UrlObject } from "url";
+import { type Route } from "next";
+import Link, { type LinkProps } from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/utils";
+
+interface Props<T extends string> extends LinkProps<T> {
+  href: Route<T> | UrlObject;
+  children?: React.ReactNode;
+  exact?: boolean;
+  className?: string;
+  activeClassName?: string;
+}
+
+export const ActiveLink = <T extends string>({
+  href,
+  children,
+  exact = true,
+  className,
+  activeClassName,
+  ...rest
+}: Props<T>) => {
+  const pathname = usePathname();
+
+  const url = typeof href === "object" ? href.pathname : href;
+  const query = typeof href === "object" ? href.query : {};
+  const isActive = exact ? pathname === url : pathname.includes(url!);
+
+  return (
+    <Link
+      href={{
+        pathname: url,
+        query,
+      }}
+      aria-current={isActive ? "page" : undefined}
+      className={cn(className, isActive && activeClassName)}
+      {...rest}
+    >
+      {children}
+    </Link>
+  );
+};

--- a/src/components/shared/Container.tsx
+++ b/src/components/shared/Container.tsx
@@ -1,4 +1,5 @@
 import { ElementType, ReactNode } from "react";
+import { cn } from "@/utils";
 
 interface ContainerProps {
   children: ReactNode;
@@ -13,7 +14,10 @@ const Container: React.FC<ContainerProps> = ({
 }) => {
   return (
     <Container
-      className={`mx-auto w-full max-w-[767px] px-4 tablet:max-w-[1279px] desktop:max-w-[1440px] desktop:px-6 ${className}`}
+      className={cn(
+        "mx-auto w-full max-w-[767px] px-4 tablet:max-w-[1279px] desktop:max-w-[1440px] desktop:px-6",
+        className,
+      )}
     >
       {children}
     </Container>

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,4 @@
+import clsx, { type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export const cn = (...classes: ClassValue[]) => twMerge(clsx(...classes));


### PR DESCRIPTION
This pull request introduces a new `ActiveLink` component to enhance navigation functionality and provide active state styling. Additionally, unit tests for the component have been implemented to ensure its reliability and maintainability.

### Changes Made
1. **ActiveLink Component**
   - Added a reusable `ActiveLink` component to handle active link styling based on the current route.
   - Supports:
     - Exact matching (`exact` prop, default `true`).
     - Customizable `className` and `activeClassName` for active state styling.
     - Compatibility with `next/link` and `next/navigation`.
   - Type-safe integration with `next`'s `Route` and `UrlObject`.

2. **Unit Tests**
   - Wrote comprehensive unit tests to validate the component's functionality, covering:
     - Proper application of `activeClassName` based on the current route.
     - Support for exact and partial matching.
     - Correct handling of custom `className` and children rendering.