### PR TITLE
fix/ replace div with fragment in Heading component for cleaner markup

### DIFF
--- a/src/components/shared/Heading/Heading.tsx
+++ b/src/components/shared/Heading/Heading.tsx
@@ -53,7 +53,7 @@ export const Heading = ({
   };
 
   return (
-    <div className="flex flex-col items-center">
+    <>
       <HeadingTag
         className={clsx(
           contrastStyle[contrast],
@@ -75,6 +75,6 @@ export const Heading = ({
           )}
         />
       )}
-    </div>
+    </>
   );
 };


### PR DESCRIPTION
I've deleted <div> element in component to have easier styling possibillity and due to the fact that this <div> was unnecessary.