### PR TITLE
Landing contrast fixes

### DIFF
--- a/src/components/AboutUsLanding/AboutUsLanding.tsx
+++ b/src/components/AboutUsLanding/AboutUsLanding.tsx
@@ -22,7 +22,8 @@ const AboutUsLanding = () => {
         <Button
           label="Poznajmy się"
           ariaDescription="Poznajmy się"
-          variant="secondary"
+          variant="primary"
+          className="contrast:bg-yellowContrast contrast:text-black00"
         />
       </Container>
       <div className="flex w-full flex-col gap-10 tablet:snap-mandatory tablet:flex-row tablet:overflow-x-auto tablet:scroll-smooth tablet:px-11 desktop:mx-auto desktop:max-w-[1440px] desktop:items-center desktop:justify-center desktop:gap-6 desktop:overflow-x-hidden desktop:px-28">

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -6,7 +6,7 @@ import { FooterSupport } from "./FooterSupport";
 import { FooterLegalInfo } from "./FooterLegalInfo";
 
 export const Footer = () => (
-  <footer className="w-full bg-greenMain px-6 py-8 text-white">
+  <footer className="w-full bg-greenMain px-6 py-8 text-white contrast:bg-yellowContrast contrast:text-black00">
     <Container>
       <div className="flex flex-col gap-8 md:grid md:grid-cols-[minmax(150px,200px)_1fr] md:gap-4 lg:grid lg:grid-cols-[200px_1fr] lg:items-start lg:gap-8">
         <FooterColumn>
@@ -42,4 +42,6 @@ const Logo = () => (
   />
 );
 
-const Divider = () => <div className="my-8 h-[1px] w-full bg-white" />;
+const Divider = () => (
+  <hr className="my-8 w-full border-white contrast:border-black00" />
+);

--- a/src/components/NewsLanding/NewsLanding.tsx
+++ b/src/components/NewsLanding/NewsLanding.tsx
@@ -18,7 +18,7 @@ const NewsLanding = async () => {
 
   return (
     <section>
-      <div className="flex items-center justify-center bg-white py-10 contrast:bg-black">
+      <div className="flex items-center justify-center bg-white py-10 contrast:bg-black00">
         <Heading variant="h2" color="green" contrast="yellow" underline>
           Aktualności
         </Heading>

--- a/src/components/shared/AboutUsLandingCard/AboutUsLandingCard.tsx
+++ b/src/components/shared/AboutUsLandingCard/AboutUsLandingCard.tsx
@@ -36,11 +36,7 @@ const AboutUsLandingCard = ({
       <p className="text-white contrast:text-black tablet:mb-1">
         {description}
       </p>
-      <Button
-        label={buttonLabel}
-        ariaDescription={buttonLabel}
-        variant="secondary"
-      />
+      <Button label={buttonLabel} ariaDescription={buttonLabel} />
     </Container>
   );
 };


### PR DESCRIPTION
Aligning with the design
In the design the Calendar Button is `yellow` in contrast mode - but I think it is better as `black`. Matches with other Buttons on yellow backgrounds.

⚠️ Branched out from: https://github.com/Delicadency/AK1944/pull/49

# After (left) - Before (right)
![Zrzut ekranu 2025-02-11 o 22 24 12 (2)](https://github.com/user-attachments/assets/e53f711a-9267-4fd3-a5f4-2d39ae84766a)
![Zrzut ekranu 2025-02-11 o 22 23 52 (2)](https://github.com/user-attachments/assets/9b6d2926-7305-454e-9490-002a640b2d09)
