### PR TITLE
fix/map scroll

### DIFF
--- a/src/app/szlak-partyzancki/_components/Map.tsx
+++ b/src/app/szlak-partyzancki/_components/Map.tsx
@@ -5,13 +5,26 @@ type MapProps = {
   };
 };
 
+const disableScroll = () => {
+  const scrollbarWidth =
+    window.innerWidth - document.documentElement.clientWidth;
+  document.body.style.paddingRight = `${scrollbarWidth}px`;
+  document.body.style.overflow = "hidden";
+};
+
+const enableScroll = () => {
+  document.body.style = "";
+};
+
 export const Map = ({ map }: MapProps) => {
   return (
-    <section className="pb-12 pt-6 desktop:pb-20 desktop:pt-10 ">
+    <section className="pb-12 pt-6 desktop:pb-20 desktop:pt-10">
       <iframe
         className="h-[50vh] w-full desktop:h-[816px]"
         src={map.iframeUrl}
         loading="lazy"
+        onMouseEnter={disableScroll}
+        onMouseLeave={enableScroll}
       ></iframe>
       <div className="w-full py-1">
         <a


### PR DESCRIPTION
- disable body scroll on map hover to prevent accidental scrolling
- prevent layout shift by accounting for scrollbar width